### PR TITLE
feat: add nullable rule as opt 

### DIFF
--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -689,6 +689,7 @@ defmodule Goal do
     |> validate_required_fields(schema)
     |> validate_basic_fields(schema)
     |> validate_nested_fields(types, schema)
+    |> validate_nullable_fields(schema)
   end
 
   @doc """
@@ -821,6 +822,23 @@ defmodule Goal do
       schema
       |> Map.get(field, [])
       |> validate_fields(field, changeset_acc)
+    end)
+  end
+
+  @spec validate_nullable_fields(Ecto.Changeset.t(), any()) :: any()
+  def validate_nullable_fields(%Changeset{changes: changes} = changeset, schema) do
+    Enum.reduce(schema, changeset, fn {field, rules}, acc ->
+      case Keyword.get(rules, :nullable) do
+        false ->
+          if is_nil(changes[field]) do
+            Ecto.Changeset.add_error(acc, field, "can't be nil")
+          else
+            acc
+          end
+
+        _ ->
+          acc
+      end
     end)
   end
 

--- a/lib/goal.ex
+++ b/lib/goal.ex
@@ -825,19 +825,13 @@ defmodule Goal do
     end)
   end
 
-  @spec validate_nullable_fields(Ecto.Changeset.t(), any()) :: any()
-  def validate_nullable_fields(%Changeset{changes: changes} = changeset, schema) do
+  defp validate_nullable_fields(%Changeset{changes: changes} = changeset, schema) do
     Enum.reduce(schema, changeset, fn {field, rules}, acc ->
-      case Keyword.get(rules, :nullable) do
-        false ->
-          if is_nil(changes[field]) do
-            Ecto.Changeset.add_error(acc, field, "can't be nil")
-          else
-            acc
-          end
-
-        _ ->
-          acc
+      with false <- Keyword.get(rules, :nullable, true),
+           nil <- Map.get(changes, field, false) do
+        Changeset.add_error(acc, field, "can't be nil")
+      else
+        _ -> acc
       end
     end)
   end

--- a/test/goal_test.exs
+++ b/test/goal_test.exs
@@ -75,6 +75,12 @@ defmodule GoalTest do
     optional(:name, :string, default: "The one who shall not be named")
   end
 
+  defparams :nullable do
+    optional(:field1, :string, nullable: true)
+    optional(:field2, :string, nullable: false)
+    optional(:field3, :string, nullable: false)
+  end
+
   describe "__using__/1" do
     test "schema/0" do
       assert schema() == %{id: [type: :integer, required: true]}
@@ -305,6 +311,15 @@ defmodule GoalTest do
 
       assert validate(:defaults, %{status: :done, name: "Voldemort"}) ==
                {:ok, %{status: :done, name: "Voldemort"}}
+
+      assert {:error,
+              %Ecto.Changeset{
+                action: :validate,
+                changes: %{},
+                errors: [field2: {"can't be nil", []}],
+                data: %{},
+                valid?: false
+              }} = validate(:nullable, %{field2: nil, field3: "some value"})
     end
   end
 


### PR DESCRIPTION
There are times where a caller might explicitly want to pass `nil` as a value and it is fine, but there are also times where it is not ok. This PR makes a `nullable` rule, which will add an error to changeset on `validate/2`.

Examples: 
```elixir 
defparams :nullable do
  optional(:last_name, :string, nullable: true) # no ecto changeset validation error
  optional(:middle_name, :string)  # no ecto changeset validation error
  optional(:age, :integer, nullable: false) # maybe return ecto changeset error if param is passed as `nil`
end
```